### PR TITLE
Bugfix

### DIFF
--- a/examples/microbenchmarks/blocksize_tuning/eval_microbenchmark.py
+++ b/examples/microbenchmarks/blocksize_tuning/eval_microbenchmark.py
@@ -5,12 +5,12 @@ import argparse
 import settings
 
 parser = argparse.ArgumentParser(description='Run microbenchmarks')
-parser.add_argument('--small', action="store_false", help='use small-size inputs')
+parser.add_argument('--small', action="store_true", help='use small-size inputs')
 
 args = parser.parse_args()
 use_large = True
 tests = settings.large_tests
-if (args.small != None):
+if args.small:
   use_large = False
   tests = settings.small_tests
 

--- a/examples/microbenchmarks/blocksize_tuning/run.py
+++ b/examples/microbenchmarks/blocksize_tuning/run.py
@@ -6,12 +6,12 @@ import settings
 # Run tests based on settings and generate raw_output files.
 
 parser = argparse.ArgumentParser(description='Run microbenchmarks')
-parser.add_argument('--small', action="store_false", help='use small-size inputs')
+parser.add_argument('--small', action="store_true", help='use small-size inputs')
 
 args = parser.parse_args()
 use_large = True
 tests = settings.large_tests
-if (args.small != None):
+if args.small:
   use_large = False
   tests = settings.small_tests
 

--- a/examples/microbenchmarks/blocksize_vs_space/eval_microbenchmark.py
+++ b/examples/microbenchmarks/blocksize_vs_space/eval_microbenchmark.py
@@ -5,12 +5,12 @@ import argparse
 import settings
 
 parser = argparse.ArgumentParser(description='Run microbenchmarks')
-parser.add_argument('--small', action="store_false", help='use small-size inputs')
+parser.add_argument('--small', action="store_true", help='use small-size inputs')
 
 args = parser.parse_args()
 use_large = True
 tests = settings.large_tests
-if (args.small != None):
+if args.small:
   use_large = False
   tests = settings.small_tests
 

--- a/examples/microbenchmarks/blocksize_vs_space/run.py
+++ b/examples/microbenchmarks/blocksize_vs_space/run.py
@@ -6,12 +6,12 @@ import settings
 # Run tests based on settings and generate raw_output files.
 
 parser = argparse.ArgumentParser(description='Run microbenchmarks')
-parser.add_argument('--small', action="store_false", help='use small-size inputs')
+parser.add_argument('--small', action="store_true", help='use small-size inputs')
 
 args = parser.parse_args()
 use_large = True
 tests = settings.large_tests
-if (args.small != None):
+if args.small:
   use_large = False
   tests = settings.small_tests
 

--- a/examples/microbenchmarks/experiments/eval_microbenchmark.py
+++ b/examples/microbenchmarks/experiments/eval_microbenchmark.py
@@ -9,13 +9,13 @@ results_file = "microbenchmark_results.txt"
 tab = {}
 
 parser = argparse.ArgumentParser(description='Run microbenchmarks')
-parser.add_argument('--small', action="store_false", help='use small-size inputs')
+parser.add_argument('--small', action="store_true", help='use small-size inputs')
 
 args = parser.parse_args()
 use_large = True
 unaug_tests = settings.large_unaug_tests
 aug_tests = settings.large_aug_tests
-if (args.small != None):
+if args.small:
   use_large = False
   unaug_tests = settings.small_unaug_tests
   aug_tests = settings.small_aug_tests

--- a/examples/microbenchmarks/experiments/run_microbenchmark.py
+++ b/examples/microbenchmarks/experiments/run_microbenchmark.py
@@ -6,13 +6,13 @@ import settings
 # Run tests based on settings and generate raw_output files.
 
 parser = argparse.ArgumentParser(description='Run microbenchmarks')
-parser.add_argument('--small', action="store_false", help='use small-size inputs')
+parser.add_argument('--small', action="store_true", help='use small-size inputs')
 
 args = parser.parse_args()
 use_large = True
 unaug_tests = settings.large_unaug_tests
 aug_tests = settings.large_aug_tests
-if (args.small != None):
+if args.small:
   use_large = False
   unaug_tests = settings.small_unaug_tests
   aug_tests = settings.small_aug_tests

--- a/examples/microbenchmarks/testParallel-PAM.cpp
+++ b/examples/microbenchmarks/testParallel-PAM.cpp
@@ -97,7 +97,7 @@ std::mt19937_64& get_rand_gen() {
 parlay::sequence<par> uniform_input(size_t n, size_t window,
                                   bool shuffle = false) {
   auto g = [&](size_t i) {
-    uniform_int_distribution<> r_keys(1, window);
+    uniform_int_distribution<size_t> r_keys(1, window);
     key_type key = r_keys(get_rand_gen());
     key_type val = i;
     return make_pair(key, val);
@@ -113,7 +113,7 @@ parlay::sequence<par> uniform_input(size_t n, size_t window,
 
 parlay::sequence<par> uniform_input_unsorted(size_t n, size_t window) {
   auto f = [&](size_t i) {
-    uniform_int_distribution<> r_keys(1, window);
+    uniform_int_distribution<size_t> r_keys(1, window);
     key_type k = r_keys(get_rand_gen());
     key_type c = r_keys(get_rand_gen());
     return make_pair(k, c);

--- a/examples/microbenchmarks/testParallel.cpp
+++ b/examples/microbenchmarks/testParallel.cpp
@@ -107,7 +107,7 @@ std::mt19937_64& get_rand_gen() {
 parlay::sequence<par> uniform_input(size_t n, size_t window,
                                   bool shuffle = false) {
   auto g = [&](size_t i) {
-    uniform_int_distribution<> r_keys(1, window);
+    uniform_int_distribution<size_t> r_keys(1, window);
     key_type key = r_keys(get_rand_gen());
     key_type val = i;
     return make_pair(key, val);
@@ -123,7 +123,7 @@ parlay::sequence<par> uniform_input(size_t n, size_t window,
 
 parlay::sequence<par> uniform_input_unsorted(size_t n, size_t window) {
   auto f = [&](size_t i) {
-    uniform_int_distribution<> r_keys(1, window);
+    uniform_int_distribution<size_t> r_keys(1, window);
     key_type k = r_keys(get_rand_gen());
     key_type c = r_keys(get_rand_gen());
     return make_pair(k, c);


### PR DESCRIPTION
**Uniform distribution**
Invoking `uniform_input_unsorted(n,4294967295)` resulted in calling `std::uniform_int_distribution<int>(1,-1)`, which is an undefined behavior. Fixed it by changing the type to `std::uniform_int_distribution<size_t>`.

**--small flag**
`parser.add_argument('--small', action="store_false", ...)` assigned a default value to `args.small` so the scripts would always use the small datasets regardless of `--small` flag. Besides, `store_false` seemed to have the opposite behavior to the literal meaning of this flag.