### PR TITLE
feat: basic_node allocation and aug_node iterate method

### DIFF
--- a/include/cpam/augmented_node.h
+++ b/include/cpam/augmented_node.h
@@ -160,13 +160,13 @@ struct aug_node : public basic_node<balance,
   template<typename F>
   static void iterate_seq(node* a, const F& f) {
     if (!a) return;
-    if (basic::is_regular(a)) {
-      auto r = basic::cast_to_regular(a);
+    if (is_regular(a)) {
+      auto r = cast_to_regular(a);
       iterate_seq(r->lc, f);
       f(get_entry(r));
       iterate_seq(r->rc, f);
     } else {
-      auto c = basic::cast_to_compressed(a);
+      auto c = cast_to_compressed(a);
       uint8_t* data_start = (((uint8_t*)c) + sizeof(aug_compressed_node));
       AugEntryEncoder::decode(data_start, c->s, f);
     }

--- a/include/cpam/basic_node.h
+++ b/include/cpam/basic_node.h
@@ -193,7 +193,7 @@ public:
     assert(s <= 2*B);
 
     size_t encoded_size = EntryEncoder::encoded_size(e, s);
-    size_t node_size = 3*sizeof(node_size_t) + encoded_size;
+    size_t node_size = sizeof(compressed_node) + encoded_size;
     compressed_node* c_node = (compressed_node*)utils::new_array_no_init<uint8_t>(node_size);
     //compressed_node* c_node = (compressed_node*)complex_allocator::alloc();
 
@@ -201,7 +201,7 @@ public:
     c_node->s = s;
     c_node->size_in_bytes = node_size;
 
-    uint8_t* encoded_data = (((uint8_t*)c_node) + 3*sizeof(node_size_t));
+    uint8_t* encoded_data = (((uint8_t*)c_node) + sizeof(compressed_node));
     EntryEncoder::encode(e, s, encoded_data);
 
     check_compressed_node(c_node);


### PR DESCRIPTION
- The basic::compressed_node should allocate memory based on its size, rather than the hard-coded value, which may bring trouble when the developer wants to change the node structure.
- When traversing the tree in augmented_node, one should cast the node to the augmented_node type rather than the basic node, as this may incur a different offset when access the encoded_data.